### PR TITLE
Configurationfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ to the `require` section of your application's `composer.json` file.
 
 * [Sign up for an reCAPTCHA API keys](https://www.google.com/recaptcha/admin#createsite).
 
+* Configure the component in your configuration file (web.php). The parameters siteKey and secret are optional. But if you leave them out you need to set them in every validation rule and every view where you want to use this widget. If a siteKey or secret is set in an individual view or validationrule that would overrule what is set in the config.
+```php
+'components' => [
+    'reCaptcha' => [
+        'name' => 'reCaptcha',
+        'class' => 'himiklab\yii2\recaptcha\ReCaptcha',
+        'siteKey' => '6Le0uwATAAAAAN4QWSko9Dk1zSX_HokHWfrDH0cq',
+        'secret' => '6Le0uwATAAAAAARNVzCKlrAPPXlybzvHuoAyCrJa',
+    ],
+    ...
+```
+
 * Add `ReCaptchaValidator` in your model, for example:
 
 ```php
@@ -48,6 +60,18 @@ public function rules()
 }
 ```
 
+or simply
+
+```php
+public function rules()
+{
+  return [
+      // ...
+      [[], \himiklab\yii2\recaptcha\ReCaptchaValidator::className()]
+  ];
+}
+```
+
 Usage
 -----
 For example:
@@ -67,6 +91,20 @@ or
     'siteKey' => 'your siteKey',
     'widgetOptions' => ['class' => 'col-sm-offset-3']
 ]) ?>
+```
+
+or
+
+```php
+<?php use himiklab\yii2\recaptcha\ReCaptcha; ?>
+<?= $form->field($model, 'reCaptcha')->widget(ReCaptcha::className()) ?>
+```
+
+or simply
+
+```php
+<?php use himiklab\yii2\recaptcha\ReCaptcha; ?>
+<?= ReCaptcha::widget(['name' => 'reCaptcha']) ?>
 ```
 
 Resources

--- a/ReCaptcha.php
+++ b/ReCaptcha.php
@@ -51,6 +51,14 @@ class ReCaptcha extends InputWidget
     /** @var string Your sitekey. */
     public $siteKey;
 
+    /** @var string Your secret. */
+    public $secret;
+    
+    public $_definitions = [
+        'secret',
+        'siteKey'
+    ];
+
     /** @var string The color theme of the widget. [[THEME_LIGHT]] (default) or [[THEME_DARK]] */
     public $theme;
 
@@ -66,9 +74,14 @@ class ReCaptcha extends InputWidget
     public function init()
     {
         parent::init();
+        
 
         if (empty($this->siteKey)) {
-            throw new InvalidConfigException('Required `siteKey` param isn\'t set.');
+            if(!empty(\Yii::$app->reCaptcha->siteKey)){
+                $this->siteKey = \Yii::$app->reCaptcha->siteKey;
+            } else {
+                throw new InvalidConfigException('Required `siteKey` param isn\'t set.');
+            }
         }
 
         $view = $this->view;

--- a/ReCaptchaValidator.php
+++ b/ReCaptchaValidator.php
@@ -34,7 +34,11 @@ class ReCaptchaValidator extends Validator
     {
         parent::init();
         if (strlen($this->secret) === 0) {
-            throw new InvalidConfigException('Required `secret` param isn\'t set.');
+            if(!emtpy(\Yii::$app->reCaptcha->secret)){
+                $this->secret = \Yii::$app->reCaptcha->secret;
+            } else {
+                throw new InvalidConfigException('Required `secret` param isn\'t set.');
+            }
         }
 
         if ($this->message === null) {


### PR DESCRIPTION
Selecting the siteKey and secret from the configuration if it is not set in the view or in the validation rule.
This way we do not need to write the siteKey everywhere we want to use the widget. And we do not need to write the secret in every validation rule.

One bad thing is that we need to always write the following in the configurationfile (web.php) in order to use this widget after this update.

``` php
    'components' => [
        'reCaptcha' => [
            'name' => 'reCaptcha',
            'class' => 'himiklab\yii2\recaptcha\ReCaptcha',
        ],
    ...
```
