### PR TITLE
Custom message when validation fails

### DIFF
--- a/ReCaptchaValidator.php
+++ b/ReCaptchaValidator.php
@@ -29,6 +29,8 @@ class ReCaptchaValidator extends Validator
 
     /** @var string The shared key between your site and ReCAPTCHA. */
     public $secret;
+    
+    public $uncheckedMessage;
 
     public function init()
     {
@@ -54,7 +56,7 @@ class ReCaptchaValidator extends Validator
      */
     public function clientValidateAttribute($model, $attribute, $view)
     {
-        $message = Yii::t(
+        $message = $this->uncheckedMessage ? $this->uncheckedMessage : Yii::t(
             'yii',
             '{attribute} cannot be blank.',
             ['attribute' => $model->getAttributeLabel($attribute)]


### PR DESCRIPTION
I added a property to the `ReCaptchaValidator` class, so when the validation fails you can show a custom message instead of the default "{attribute} cannot be blank" message.
