### PR TITLE
#33 fix local sitekey and secret use

### DIFF
--- a/ReCaptcha.php
+++ b/ReCaptcha.php
@@ -51,6 +51,9 @@ class ReCaptcha extends InputWidget
     const SIZE_NORMAL = 'normal';
     const SIZE_COMPACT = 'compact';
 
+    const LOCAL_SITEKEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+    const LOCAL_SECRET = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
+
     /** @var string Your sitekey. */
     public $siteKey;
 
@@ -83,6 +86,8 @@ class ReCaptcha extends InputWidget
         if (empty($this->siteKey)) {
             if (!empty(Yii::$app->reCaptcha->siteKey)) {
                 $this->siteKey = Yii::$app->reCaptcha->siteKey;
+            } else if (YII_DEBUG) {
+                $this->siteKey = self::LOCAL_SITEKEY;
             } else {
                 throw new InvalidConfigException('Required `siteKey` param isn\'t set.');
             }
@@ -173,4 +178,15 @@ class ReCaptcha extends InputWidget
         $view->registerJs($jsExpCode, $view::POS_BEGIN);
         echo Html::input('hidden', $inputName, null, ['id' => $inputId]);
     }
+
+    public function getLocalSecret()
+    {
+        return self::LOCAL_SECRET;
+    }
+
+    public function getLocalSitekey()
+    {
+        return self::LOCAL_SITEKEY;
+    }
+
 }

--- a/ReCaptchaValidator.php
+++ b/ReCaptchaValidator.php
@@ -44,6 +44,8 @@ class ReCaptchaValidator extends Validator
         if (empty($this->secret)) {
             if (!empty(Yii::$app->reCaptcha->secret)) {
                 $this->secret = Yii::$app->reCaptcha->secret;
+            } else if (YII_DEBUG) {
+                $this->secret = Yii::$app->reCaptcha->localSecret;
             } else {
                 throw new InvalidConfigException('Required `secret` param isn\'t set.');
             }


### PR DESCRIPTION
The extension does not handle the sitekey or secret for dev/localhost use. According to the docs, we are supposed to use the following keys for testing (like on localhost) or before client provides his real keys.

> Site key: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
> Secret key: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

This allows us to keep the values empty in our config, and will replace them with the above when YII_DEBUG === true, thus allowing this extension to once again work properly while developing locally :)

I will give 2 weeks for this to get merged or at least a comment from the original developer. It looks like he has not been around for a while, and issues are still around from 2015. I may have to revive it on my own, so I have this fix via packagist. I would be willing to look at and fix issues, where appropriate, if I take it over.

This is addressing my open issue #33 
