### PR TITLE
Fix for php 7

### DIFF
--- a/ReCaptchaValidator.php
+++ b/ReCaptchaValidator.php
@@ -42,7 +42,7 @@ class ReCaptchaValidator extends Validator
     {
         parent::init();
         if (empty($this->secret)) {
-            if (!empty(Yii::$app->reCaptcha->secret)) {
+            if (!empty(Yii::$app->get('reCaptcha')->secret)) {
                 $this->secret = Yii::$app->reCaptcha->secret;
             } else {
                 throw new InvalidConfigException('Required `secret` param isn\'t set.');


### PR DESCRIPTION
Function empty() in php 7 don't create reCaptcha module instance on call empty(Yii::$app->reCaptcha->secret) its just return false if module instance don't exist yet. Yii::$app->get() creates module instance if its don' exist and return its. Think its simpliest solution.
#26 #28 #36