### PR TITLE
Fixed an issue that throws a misconfiguration error in my setup

### DIFF
--- a/ReCaptcha.php
+++ b/ReCaptcha.php
@@ -81,12 +81,13 @@ class ReCaptcha extends InputWidget
     public function run()
     {
         if (empty($this->siteKey)) {
-            if (!empty(Yii::$app->reCaptcha->siteKey)) {
-                $this->siteKey = Yii::$app->reCaptcha->siteKey;
+	    $siteKey = Yii::$app->reCaptcha->siteKey;
+            if (!empty($siteKey)) {
+                $this->siteKey = $siteKey;
             } else {
                 throw new InvalidConfigException('Required `siteKey` param isn\'t set.');
             }
-        }
+	}
 
         $view = $this->view;
         $view->registerJsFile(

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "himiklab/yii2-recaptcha-widget",
+    "name": "gbabic/yii2-recaptcha-widget",
     "description": "Yii2 Google reCAPTCHA widget",
     "keywords": ["yii2", "captcha", "recaptcha", "google", "widget"],
     "type": "yii2-extension",
@@ -12,7 +12,10 @@
         {
             "name": "HimikLab",
             "homepage": "https://github.com/himiklab/"
-        }
+        },
+	{
+		"name": "Goran Babic",
+		"homepage": "http://github.com/gbabic/"
     ],
     "require": {
         "yiisoft/yii2": "*"


### PR DESCRIPTION
Running:
```php
<?= ReCaptcha::widget(['name' => 'reCaptcha']) ?>
```

Would throw a misconfiguration error. Seems that the empty() query returns true the first time Yii::$app->reCaptcha->siteKey is called for some reason.

Storing it in a variable before the empty check gets around this problem.