### PR TITLE
fix JS_API_URL 404 response bug

### DIFF
--- a/ReCaptcha.php
+++ b/ReCaptcha.php
@@ -40,7 +40,7 @@ use yii\widgets\InputWidget;
  */
 class ReCaptcha extends InputWidget
 {
-    const JS_API_URL = '//www.google.com/recaptcha/api.js';
+    const JS_API_URL = '//google.com/recaptcha/api.js';
 
     const THEME_LIGHT = 'light';
     const THEME_DARK = 'dark';


### PR DESCRIPTION
widget trying to get `domain.com/www.google.com/recaptcha/api.js` instead of `www.google.com/recaptcha/api.js`

